### PR TITLE
習慣の記録単位を変更できるようにする

### DIFF
--- a/app/assets/stylesheets/habits.scss
+++ b/app/assets/stylesheets/habits.scss
@@ -1,4 +1,4 @@
-/* habits#new */
+/* habits#new, #edit */
 #main {
   .field_with_errors {
     display: contents;
@@ -9,7 +9,7 @@
     font-size: 0.8em;
   }
 
-  .habit_content_form {
+  .habit_content_form, .habit_report_unit_form {
     margin: 1em 0;
 
     input {

--- a/app/controllers/habits_controller.rb
+++ b/app/controllers/habits_controller.rb
@@ -51,7 +51,7 @@ class HabitsController < ApplicationController
   private
 
   def habit_params
-    params.require(:habit).permit(:user_id, :content, :record_type, :open_range)
+    params.require(:habit).permit(:user_id, :content, :record_type, :report_unit)
   end
 
   def correct_user

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -13,7 +13,7 @@ class Habit < ApplicationRecord
   def calculation_management_value
     self.total_days = count_total_days
     self.continuation_days = count_continuation_days
-    self.total_time = count_total_time if record_type == REPORT_TYPE
+    self.total_report = count_total_report if record_type == REPORT_TYPE
     save
   end
 
@@ -35,11 +35,11 @@ class Habit < ApplicationRecord
     count_days
   end
 
-  def count_total_time
-    time = 0
+  def count_total_report
+    report = 0
     achievements.each do |achievement|
-      time += achievement.report
+      report += achievement.report
     end
-    time
+    report
   end
 end

--- a/app/models/habit.rb
+++ b/app/models/habit.rb
@@ -8,6 +8,7 @@ class Habit < ApplicationRecord
 
   validates :content, presence: true, length: { maximum: 40 }
   validates :record_type, inclusion: { in: [true, false] }
+  validates :report_unit, presence: true, length: { maximum: 8 }
 
   def calculation_management_value
     self.total_days = count_total_days

--- a/app/views/habits/_habit_form.html.erb
+++ b/app/views/habits/_habit_form.html.erb
@@ -10,7 +10,7 @@
     <%= f.radio_button :record_type, true %>チェックタイプ　<%= f.radio_button :record_type, false %>記録タイプ
   </div>
   <% if title == "習慣登録情報編集" && @habit.record_type == Habit::REPORT_TYPE %>
-    <div>
+    <div class="habit_report_unit_form">
       <%= f.label :report_unit, "記録単位" %>
       <%= f.text_field :report_unit, size: 30 %>
     </div>

--- a/app/views/habits/_habit_form.html.erb
+++ b/app/views/habits/_habit_form.html.erb
@@ -9,5 +9,11 @@
     <%= f.label :record_type, "習慣の種類" %>
     <%= f.radio_button :record_type, true %>チェックタイプ　<%= f.radio_button :record_type, false %>記録タイプ
   </div>
+  <% if title == "習慣登録情報編集" && @habit.record_type == Habit::REPORT_TYPE %>
+    <div>
+      <%= f.label :report_unit, "記録単位" %>
+      <%= f.text_field :report_unit, size: 30 %>
+    </div>
+  <% end %>
   <%= f.submit submit_button_name %>
 <% end %>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -7,7 +7,7 @@
       <li class="habit_count">継続日数　　　：<%= @habit.continuation_days %>日</li>
       <li class="habit_count">トータル日数　：<%= @habit.total_days %>日</li>
       <% if @habit.record_type == Habit::REPORT_TYPE %>
-        <li class="habit_count">トータル時間　：<%= @habit.total_time %>時間</li>
+        <li class="habit_count">トータル時間　：<%= @habit.total_time %><%= @habit.report_unit %></li>
       <% end %>
     </ul>
   </div>
@@ -19,7 +19,7 @@
         <div class="check_true"></div>
       <% end %>
       <% if @habit.record_type == Habit::REPORT_TYPE %>
-        <p class="achievement_report"><%= achievement.report %>時間</p>
+        <p class="achievement_report"><%= achievement.report %><%= @habit.report_unit %></p>
       <% end %>
     <% end %>
   <% end %>

--- a/app/views/habits/show.html.erb
+++ b/app/views/habits/show.html.erb
@@ -7,7 +7,7 @@
       <li class="habit_count">継続日数　　　：<%= @habit.continuation_days %>日</li>
       <li class="habit_count">トータル日数　：<%= @habit.total_days %>日</li>
       <% if @habit.record_type == Habit::REPORT_TYPE %>
-        <li class="habit_count">トータル時間　：<%= @habit.total_time %><%= @habit.report_unit %></li>
+        <li class="habit_count">トータル実績　：<%= @habit.total_report %><%= @habit.report_unit %></li>
       <% end %>
     </ul>
   </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -11,8 +11,8 @@
     </div>
     <% if @habit.record_type == Habit::REPORT_TYPE %>
       <div class="post_time_form">
-        <%= f.label "時間" %>
-        <%= f.text_field :report %>
+        <%= f.label "実績" %>
+        <%= f.text_field :report %><%= @habit.report_unit %>
       </div>
     <% end %>
     <% if @achievement.nil? || @achievement.check == false %>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -8,7 +8,7 @@
           <li>継続日数　　　：<%= habit.continuation_days %>日</li>
           <li>トータル日数　：<%= habit.total_days %>日</li>
           <% if habit.record_type == Habit::REPORT_TYPE %>
-            <li>トータル時間　：<%= habit.total_time %>時間</li>
+            <li>トータル時間　：<%= habit.total_time %><%= habit.report_unit %></li>
           <% end %>
           <% if show_edit_delete_button == false %>
             <li><%= link_to "今日の成果を投稿", new_habit_post_path(habit), class: "post_button" %></li>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -8,7 +8,7 @@
           <li>継続日数　　　：<%= habit.continuation_days %>日</li>
           <li>トータル日数　：<%= habit.total_days %>日</li>
           <% if habit.record_type == Habit::REPORT_TYPE %>
-            <li>トータル時間　：<%= habit.total_time %><%= habit.report_unit %></li>
+            <li>トータル実績　：<%= habit.total_report %><%= habit.report_unit %></li>
           <% end %>
           <% if show_edit_delete_button == false %>
             <li><%= link_to "今日の成果を投稿", new_habit_post_path(habit), class: "post_button" %></li>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -8,7 +8,7 @@
           <li>継続日数　　　：<%= habit.continuation_days %>日</li>
           <li>トータル日数　：<%= habit.total_days %>日</li>
           <% if habit.record_type == Habit::REPORT_TYPE %>
-            <li>トータル時間　：<%= habit.total_time %>時間</li>
+            <li>トータル時間　：<%= habit.total_time %><%= habit.report_unit %></li>
           <% end %>
         </ul>
       </div>

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -8,7 +8,7 @@
           <li>継続日数　　　：<%= habit.continuation_days %>日</li>
           <li>トータル日数　：<%= habit.total_days %>日</li>
           <% if habit.record_type == Habit::REPORT_TYPE %>
-            <li>トータル時間　：<%= habit.total_time %><%= habit.report_unit %></li>
+            <li>トータル実績　：<%= habit.total_report %><%= habit.report_unit %></li>
           <% end %>
         </ul>
       </div>

--- a/db/migrate/20201112003525_add_report_unit_to_habits.rb
+++ b/db/migrate/20201112003525_add_report_unit_to_habits.rb
@@ -1,5 +1,6 @@
 class AddReportUnitToHabits < ActiveRecord::Migration[5.2]
   def change
     add_column :habits, :report_unit, :string, after: :continuation_days, default: "時間", null: false
+    rename_column :habits, :total_time, :total_report
   end
 end

--- a/db/migrate/20201112003525_add_report_unit_to_habits.rb
+++ b/db/migrate/20201112003525_add_report_unit_to_habits.rb
@@ -1,0 +1,5 @@
+class AddReportUnitToHabits < ActiveRecord::Migration[5.2]
+  def change
+    add_column :habits, :report_unit, :string, after: :continuation_days, default: "時間", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2020_11_12_003525) do
     t.string "content", null: false
     t.boolean "record_type", default: true, null: false
     t.integer "total_days", default: 0
-    t.integer "total_time", default: 0
+    t.integer "total_report", default: 0
     t.integer "continuation_days", default: 0
     t.string "report_unit", default: "時間", null: false
     t.datetime "created_at", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_26_234545) do
+ActiveRecord::Schema.define(version: 2020_11_12_003525) do
 
   create_table "achievements", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "habit_id"
@@ -35,6 +35,7 @@ ActiveRecord::Schema.define(version: 2020_10_26_234545) do
     t.integer "total_days", default: 0
     t.integer "total_time", default: 0
     t.integer "continuation_days", default: 0
+    t.string "report_unit", default: "時間", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -17,9 +17,9 @@ profiles = [{ email: "yumi@example.com",   name: "yumi",    password: "aaaaaaaa"
             { email: "maeda@example.com",  name: "前田",     password: "aaaaaaaa", password_confirmation: "aaaaaaaa", confirmed_at: Time.current },
             { email: "kana@example.com",   name: "kana",    password: "aaaaaaaa", password_confirmation: "aaaaaaaa", confirmed_at: Time.current }]
 
-habits1 = [{ content: "1時間本を読む",     	record_type: false, total_days: 6, total_time: 9, continuation_days: 6, created_at: today - 5 },
-           { content: "1時間ジョギングする", record_type: false, total_days: 6, total_time: 7, continuation_days: 4, created_at: today - 6 },
-           { content: "2時間勉強する",      record_type: false, total_days: 1, total_time: 2, continuation_days: 1 },
+habits1 = [{ content: "1時間本を読む",     	record_type: false, total_days: 6, total_report: 9, continuation_days: 6, created_at: today - 5 },
+           { content: "1時間ジョギングする", record_type: false, total_days: 6, total_report: 7, continuation_days: 4, created_at: today - 6 },
+           { content: "2時間勉強する",      record_type: false, total_days: 1, total_report: 2, continuation_days: 1 },
            { content: "筋トレをする",      	record_type: true,  total_days: 1,                continuation_days: 1 },
            { content: "コードを書く",       record_type: true,  total_days: 1,                continuation_days: 1 },
            { content: "毎日散歩する",	      record_type: true,  total_days: 1,                continuation_days: 1 },

--- a/spec/factories/habits.rb
+++ b/spec/factories/habits.rb
@@ -2,6 +2,7 @@ FactoryBot.define do
   factory :habit do
     content "習慣登録テスト"
     record_type Habit::REPORT_TYPE
+    report_unit "時間"
     association :owner
   end
 end

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -118,7 +118,7 @@ RSpec.feature "Projects", type: :feature do
 
         expect(page).to have_content "習慣を登録しました"
         expect(page).to have_content "習慣登録テスト"
-        expect(page).to have_content "トータル時間　：0時間"
+        expect(page).to have_content "トータル実績　：0時間"
       end.to change(user.habits, :count).by(1)
     end
 
@@ -203,7 +203,7 @@ RSpec.feature "Projects", type: :feature do
         click_button "投稿"
 
         expect(page).to have_content "テストを行った"
-        expect(page).to have_content "トータル時間　：3時間"
+        expect(page).to have_content "トータル実績　：3時間"
       end.to change(habit.posts, :count).by(1)
     end
 

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -141,9 +141,11 @@ RSpec.feature "Projects", type: :feature do
       click_link "プロフィール"
       click_link "編集"
       fill_in "習慣名", with: "習慣編集テスト"
+      fill_in "記録単位", with: "分"
       click_button "保存"
 
       expect(page).to have_content "習慣編集テスト"
+      expect(page).to have_content "分"
     end
 
     scenario "search a habit" do

--- a/spec/models/habit_spec.rb
+++ b/spec/models/habit_spec.rb
@@ -60,6 +60,6 @@ RSpec.describe Habit, type: :model do
     habit = FactoryBot.create(:habit)
     FactoryBot.create(:achievement, :created_at_yesterday, habit: habit)
     FactoryBot.create(:achievement, habit: habit)
-    expect(habit.count_total_time).to eq 2
+    expect(habit.count_total_report).to eq 2
   end
 end

--- a/spec/models/habit_spec.rb
+++ b/spec/models/habit_spec.rb
@@ -29,6 +29,12 @@ RSpec.describe Habit, type: :model do
     expect(habit.errors[:record_type]).to include("は一覧にありません")
   end
 
+  it "is invalid without a report_unit more than the maximum characters" do
+    habit = FactoryBot.build(:habit, report_unit: "x" * 9)
+    habit.valid?
+    expect(habit.errors[:report_unit]).to include("は8文字以内で入力してください")
+  end
+
   it "returns total days" do
     achievement = FactoryBot.create(:achievement)
     habit = achievement.habit


### PR DESCRIPTION
## 何をしたいか
- 習慣の記録単位を変更できるようにし、時間だけでなく、距離や、量等の他の数値を記録していくことができるようにする

- 習慣を登録する際はデフォルトで"時間"が設定される
後でユーザーが単位を設定したい場合は、習慣編集画面から任意に単位を変更できる

## レビューしてほしいポイント
- 機能の実装方法に問題が無いか
- 画面の変更箇所に漏れが無いか

## マージ条件
- 1LGTM